### PR TITLE
Update AWS provider version to >= 6.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
Bump the required AWS provider version from >= 5.0 to >= 6.0 in versions.tf to ensure compatibility with newer features and improvements.

aws_region uses region attribute which was introduced in the aws provider version 6.

https://registry.terraform.io/providers/hashicorp/aws/6.15.0/docs/data-sources/region

https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/data-sources/region