### PR TITLE
fix: output datadog_forwarder_role_name is empty when not using existing role

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "datadog_forwarder_role_arn" {
 
 output "datadog_forwarder_role_name" {
   description = "Datadog Forwarder Lambda Function Role Name"
-  value       = var.existing_iam_role_arn == "" ? module.iam[0].iam_role_name : null
+  value       = var.existing_iam_role_arn == null ? module.iam[0].iam_role_name : null
 }
 
 output "dd_api_key_secret_arn" {


### PR DESCRIPTION
Hey 👋 

I'm migrating my log forwarding stack from Cloudformation to Terraform and I encountered an issue when wanting to add policies to the IAM role created by this module.

Testing against empty string when default value is `null` isn't working and the output return `null` independently of the role configuration.