### PR TITLE
fix(aws): replace broken readme refs with github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This Terraform module creates the Datadog Log Lambda Forwarder infrastructure in
 
 ## Usage
 
-For complete usage examples demonstrating different configuration scenarios, see the [examples](./examples/) directory:
+For complete usage examples demonstrating different configuration scenarios, see the [examples](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples) directory:
 
-- **[Basic Example](./examples/basic/)** - Simple setup with minimal configuration, includes examples for API key storage using Secrets Manager or SSM Parameter Store
-- **[VPC Example](./examples/vpc/)** - VPC deployment with enhanced metrics, custom log processing, and comprehensive tagging
-- **[Multi-Region Example](./examples/multi-region/)** - Basic forwarder setup deployed across multiple AWS regions
+- **[Basic Example](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/basic)** - Simple setup with minimal configuration, includes examples for API key storage using Secrets Manager or SSM Parameter Store
+- **[VPC Example](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/vpc)** - VPC deployment with enhanced metrics, custom log processing, and comprehensive tagging
+- **[Multi-Region Example](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/multi-region)** - Basic forwarder setup deployed across multiple AWS regions
 
 ## Requirements
 
@@ -180,14 +180,14 @@ This method automatically configures triggers for services like CloudWatch Log G
 
 ### Manual Trigger Setup
 
-The [examples](./examples/) directory contains practical implementations of log subscription filters and event triggers. Common integration patterns include:
+The [examples](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples) directory contains practical implementations of log subscription filters and event triggers. Common integration patterns include:
 
 - **CloudWatch Log Groups**: Subscription filters to forward log streams
 - **S3 Bucket Notifications**: Trigger forwarder when log files are uploaded
 - **SNS Topics**: Forward CloudWatch alarms and other notifications
 - **EventBridge Rules**: Forward custom application events
 
-See the [basic](./examples/basic/) and [vpc](./examples/vpc/) examples for complete implementation details.
+See the [basic](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/basic) and [vpc](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/vpc) examples for complete implementation details.
 
 ## IAM Permissions
 


### PR DESCRIPTION
These links were giving 404 in the terraform registry 
https://registry.terraform.io/modules/DataDog/log-lambda-forwarder-datadog/aws/latest#usage