### PR TITLE
[AWSX] feat(logs forwarder): update terraform module to enable source override

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,16 @@ For complete usage examples demonstrating different configuration scenarios, see
 
 ### Datadog Configuration
 
-| Name                          | Description                    | Type     | Default           |
-| ----------------------------- | ------------------------------ | -------- | ----------------- |
-| dd_api_key                    | Datadog API key                | `string` | `null`            |
-| dd_api_key_secret_arn         | ARN of secret storing API key  | `string` | `null`            |
-| dd_api_key_ssm_parameter_name | SSM parameter name for API key | `string` | `null`            |
-| dd_site                       | Datadog site                   | `string` | `"datadoghq.com"` |
-| dd_tags                       | Custom tags for forwarded logs | `string` | `null`            |
-| dd_trace_enabled              | Enable trace forwarding        | `bool`   | `true`            |
-| dd_enhanced_metrics           | Enable enhanced Lambda metrics | `bool`   | `false`           |
+| Name                          | Description                      | Type     | Default           |
+| ----------------------------- | -------------------------------- | -------- | ----------------- |
+| dd_api_key                    | Datadog API key                  | `string` | `null`            |
+| dd_api_key_secret_arn         | ARN of secret storing API key    | `string` | `null`            |
+| dd_api_key_ssm_parameter_name | SSM parameter name for API key   | `string` | `null`            |
+| dd_site                       | Datadog site                     | `string` | `"datadoghq.com"` |
+| dd_tags                       | Custom tags for forwarded logs   | `string` | `null`            |
+| dd_source                     | Custom source for forwarded logs | `string` | `null`            |
+| dd_trace_enabled              | Enable trace forwarding          | `bool`   | `true`            |
+| dd_enhanced_metrics           | Enable enhanced Lambda metrics   | `bool`   | `false`           |
 
 ### Tag Enrichment & Fetching
 

--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,7 @@ resource "aws_lambda_function" "forwarder" {
       # Optional environment variables
       {
         DD_TAGS                         = var.dd_tags
+        DD_SOURCE                       = var.dd_source
         DD_ENRICH_S3_TAGS               = var.dd_enrich_s3_tags != null ? tostring(var.dd_enrich_s3_tags) : null
         DD_ENRICH_CLOUDWATCH_TAGS       = var.dd_enrich_cloudwatch_tags != null ? tostring(var.dd_enrich_cloudwatch_tags) : null
         DD_FETCH_LAMBDA_TAGS            = var.dd_fetch_lambda_tags != null ? tostring(var.dd_fetch_lambda_tags) : null

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,12 @@ variable "dd_tags" {
   description = "Add custom tags to forwarded logs. Comma-delimited string without trailing comma, e.g., env:prod,stack:classic"
 }
 
+variable "dd_source" {
+  type        = string
+  default     = null
+  description = "Override the source attribute for all logs forwarded by Lambda Forwarder. By default, the Forwarder automatically detects the source based on the log origin (e.g., lambda, s3, cloudwatch, rds). When set, all logs will use the specified source value instead, and a source_overridden:true tag will be added to the logs."
+}
+
 variable "dd_enrich_s3_tags" {
   type        = bool
   default     = null


### PR DESCRIPTION
* Update module to match the recently added feature in the forwarder template which allows overriding the source for all forwarded logs
* Related PR https://github.com/DataDog/datadog-serverless-functions/pull/1037