### PR TITLE
[AWSX] fix(iam module): restrict SSM parameter IAM permissions to specific parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ module "iam" {
   permissions_boundary_arn          = var.permissions_boundary_arn
   partition                         = data.aws_partition.current.partition
   region                            = local.region
+  account_id                        = data.aws_caller_identity.current.account_id
   tags                              = var.tags
   s3_bucket_permissions             = var.dd_forwarder_existing_bucket_name != null || local.create_s3_bucket
   forwarder_bucket_arn              = local.create_s3_bucket ? aws_s3_bucket.forwarder_bucket[0].arn : null

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -105,7 +105,7 @@ resource "aws_iam_role_policy" "forwarder_policy" {
             "ssm:GetParameters",
             "ssm:GetParametersByPath"
           ]
-          Resource = "*"
+          Resource = "arn:${var.partition}:ssm:${var.region}:${var.account_id}:parameter${var.dd_api_key_ssm_parameter_name}"
         }
       ] : [],
 

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -93,3 +93,8 @@ variable "region" {
   type        = string
   description = "AWS region for resource naming"
 }
+
+variable "account_id" {
+  type        = string
+  description = "AWS account ID"
+}


### PR DESCRIPTION
Updated IAM policy to grant SSM permissions only to the specified parameter instead of using wildcard (*).

Changes:
- Add account_id variable to IAM module
- Update SSM Resource ARN to use specific parameter path
- Pass account_id from root module using data.aws_caller_identity