### PR TITLE
feat: automatic Lambda runtime detection from layer metadata

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -70,6 +70,10 @@ locals {
   )
 }
 
+data "aws_lambda_layer_version" "this" {
+  layer_version_arn = local.default_layer_arn
+}
+
 # Deprecation warnings for conflicting API key configurations.
 # These will become hard validation errors in a future major release.
 check "dd_api_key_not_used_with_secret_arn" {

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ resource "aws_lambda_function" "forwarder" {
   description   = "Pushes logs, metrics and traces from AWS to Datadog."
   role          = local.iam_role_arn
   handler       = "lambda_function.lambda_handler"
-  runtime       = var.layer_version == "latest" ? "python3.14" : (can(tonumber(var.layer_version)) && tonumber(var.layer_version) >= 94 ? "python3.14" : "python3.13")
+  runtime       = reverse(sort(tolist(data.aws_lambda_layer_version.this.compatible_runtimes)))[0]
   architectures = ["arm64"]
   memory_size   = var.memory_size
   timeout       = var.timeout

--- a/tests/create_api_key_secret_flag.tftest.hcl
+++ b/tests/create_api_key_secret_flag.tftest.hcl
@@ -23,6 +23,14 @@ mock_provider "aws" {
       dns_suffix = "amazonaws.com"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/default_config.tftest.hcl
+++ b/tests/default_config.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {
@@ -188,4 +196,3 @@ run "environment_variables_test" {
     error_message = "DD_API_KEY_SSM_NAME should not be present when using Secrets Manager"
   }
 }
-

--- a/tests/enhanced_features.tftest.hcl
+++ b/tests/enhanced_features.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/enrich_fetch_variables.tftest.hcl
+++ b/tests/enrich_fetch_variables.tftest.hcl
@@ -22,6 +22,14 @@ mock_provider "aws" {
       arn = "arn:aws:s3:::existing-datadog-bucket"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/existing_iam_role_without_bucket.tftest.hcl
+++ b/tests/existing_iam_role_without_bucket.tftest.hcl
@@ -20,6 +20,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 # Test: existing IAM role with SSM parameter (no bucket specified) - should work

--- a/tests/existing_resources.tftest.hcl
+++ b/tests/existing_resources.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/forwarder_version_tag.tftest.hcl
+++ b/tests/forwarder_version_tag.tftest.hcl
@@ -17,6 +17,16 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.12",
+        "python3.14",
+        "python3.13"
+      ]
+    }
+  }
 }
 
 variables {
@@ -45,6 +55,12 @@ run "version_tag_with_latest" {
     condition     = local.forwarder_version != null
     error_message = "local.forwarder_version should be set when using latest"
   }
+
+  # Layer runtime should be set to the latest version of compatible_runtimes
+  assert {
+    condition     = aws_lambda_function.forwarder.runtime == "python3.14"
+    error_message = "Lambda runtime should be python3.14"
+  }
 }
 
 # Test with specific layer_version
@@ -53,6 +69,15 @@ run "version_tag_with_specific_layer" {
 
   variables {
     layer_version = "92"
+  }
+
+  override_data {
+    target = data.aws_lambda_layer_version.this
+    values = {
+      compatible_runtimes = [
+        "python3.13",
+      ]
+    }
   }
 
   # Lambda should have dd_forwarder_version tag
@@ -71,6 +96,12 @@ run "version_tag_with_specific_layer" {
   assert {
     condition     = can(regex(":92$", aws_lambda_function.forwarder.layers[0]))
     error_message = "Lambda layer ARN should end with :92"
+  }
+
+  # Runtime should match the compatible_runtimes returned by the layer data source
+  assert {
+    condition     = aws_lambda_function.forwarder.runtime == "python3.13"
+    error_message = "Lambda runtime should be python3.13"
   }
 }
 
@@ -102,4 +133,3 @@ run "version_tag_with_user_tags" {
     error_message = "dd_forwarder_version tag should be added alongside user tags"
   }
 }
-

--- a/tests/multi_region.tftest.hcl
+++ b/tests/multi_region.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/optional_env_vars.tftest.hcl
+++ b/tests/optional_env_vars.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {

--- a/tests/s3_log_bucket_arns.tftest.hcl
+++ b/tests/s3_log_bucket_arns.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 # Test: Default behavior - s3:GetObject should allow all buckets for backward compatibility

--- a/tests/secrets_management.tftest.hcl
+++ b/tests/secrets_management.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 # Path 1: dd_api_key only (auto-create secret)

--- a/tests/sqs_failed_events.tftest.hcl
+++ b/tests/sqs_failed_events.tftest.hcl
@@ -18,6 +18,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 # Test: SQS URL auto-enables DD_STORE_FAILED_EVENTS and skips S3 bucket creation

--- a/tests/vpc_config.tftest.hcl
+++ b/tests/vpc_config.tftest.hcl
@@ -17,6 +17,14 @@ mock_provider "aws" {
       partition = "aws"
     }
   }
+
+  mock_data "aws_lambda_layer_version" {
+    defaults = {
+      compatible_runtimes = [
+        "python3.14",
+      ]
+    }
+  }
 }
 
 variables {


### PR DESCRIPTION
The previous implementation hardcoded runtime selection based on layer version numbers (e.g., `>= 94` → `python3.14`). This required manual updates whenever Datadog updated the forwarder layer.

We could instead read directly from the data source `aws_lambda_layer_version` and get `compatible_runtimes`. This makes the code easier to maintain.

## Implementation

Picks the latest one using `reverse(sort(tolist(...)))[0]`. The `sort` is necessary because Terraform does not guarantee set ordering, and `reverse` ensures we always pick the highest Python version.