### PR TITLE
feat: add additional_layers variable for extra Lambda layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ For complete usage examples demonstrating different configuration scenarios, see
 - **[VPC Example](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/vpc)** - VPC deployment with enhanced metrics, custom log processing, and comprehensive tagging
 - **[Multi-Region Example](https://github.com/DataDog/terraform-aws-log-lambda-forwarder-datadog/tree/main/examples/multi-region)** - Basic forwarder setup deployed across multiple AWS regions
 
+### Adding Extra Lambda Layers
+
+Use `additional_layers` to attach extra layers alongside the forwarder layer — for example, the [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension) for forwarder telemetry:
+
+```hcl
+module "datadog_forwarder" {
+  source = "DataDog/log-lambda-forwarder-datadog/aws"
+
+  dd_api_key_secret_arn = aws_secretsmanager_secret.datadog_api_key.arn
+  dd_site               = "datadoghq.com"
+
+  additional_layers = [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:94"
+  ]
+}
+```
+
+The extension reads the existing `DD_SITE` and `DD_API_KEY_SECRET_ARN` environment variables — no additional configuration is needed.
+
 ## Requirements
 
 | Name      | Version  |
@@ -64,6 +83,7 @@ For complete usage examples demonstrating different configuration scenarios, see
 | log_retention_in_days | CloudWatch log retention                                                                                                                                                          | `number`      | `90`                 |
 | layer_version         | Version of the Datadog Forwarder Lambda layer                                                                                                                                     | `string`      | `"latest"`           |
 | layer_arn             | Custom layer ARN (optional)                                                                                                                                                       | `string`      | `null`               |
+| additional_layers     | Additional Lambda layers to attach to the forwarder function (e.g., [Datadog Lambda Extension](https://github.com/DataDog/datadog-lambda-extension))                              | `list(string)` | `[]`                |
 | existing_iam_role_arn | ARN of existing IAM role to use for the Lambda function. When using an existing role, you must provide either `dd_api_key_secret_arn` or `dd_api_key_ssm_parameter_name`, and you are responsible for ensuring the role has the necessary permissions for any resources the module creates. See [Using an Existing IAM Role](#using-an-existing-iam-role) for details. | `string`      | `null`               |
 | tags                  | Resource tags                                                                                                                                                                     | `map(string)` | `{}`                 |
 

--- a/main.tf
+++ b/main.tf
@@ -205,9 +205,10 @@ resource "aws_lambda_function" "forwarder" {
   timeout       = var.timeout
 
   # Use Lambda layer
-  layers = [
-    var.layer_arn != null ? var.layer_arn : local.default_layer_arn
-  ]
+  layers = concat(
+    [var.layer_arn != null ? var.layer_arn : local.default_layer_arn],
+    var.additional_layers
+  )
 
   # Static placeholder zip file for layer-based installation
   filename = local.placeholder_zip_path

--- a/variables.tf
+++ b/variables.tf
@@ -187,6 +187,12 @@ variable "layer_arn" {
   description = "ARN for the layer containing the forwarder code. If empty, the script will use the version of the layer the forwarder was published with."
 }
 
+variable "additional_layers" {
+  type        = list(string)
+  default     = []
+  description = "Additional Lambda layers to attach to the forwarder function (e.g., Datadog Lambda Extension)."
+}
+
 # Datadog configuration
 variable "dd_tags" {
   type        = string


### PR DESCRIPTION
## Summary

- Add `additional_layers` variable (`list(string)`, default `[]`) to allow attaching extra Lambda layers to the forwarder function
- Modify the `layers` attribute to `concat()` the default forwarder layer with any additional layers

This enables consumers to attach the Datadog Lambda Extension (or other layers) alongside the forwarder layer without needing to override `layer_arn`.

## Motivation

The `aws-datadog-forwarder` wrapper module in [cloud-inventory](https://github.com/DataDog/cloud-inventory) needs to attach the Datadog Lambda Extension layer for Lambda telemetry. The current module only supports a single layer via `layer_arn`/`layer_version`, with no way to add supplementary layers.

## Test plan

- [ ] Existing tests pass (no behavioral change when `additional_layers` is empty)
- [ ] Verify `terraform plan` with `additional_layers` set to a valid layer ARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)