### PR TITLE
fix: remove cross-variable validation that broke tonumber("latest")

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For complete usage examples demonstrating different configuration scenarios, see
 | dd_max_workers                    | Max concurrent workers                                 | `string` | `null`  |
 | dd_log_level                      | Log level                                              | `string` | `null`  |
 | dd_store_failed_events            | Store failed events in S3                              | `bool`   | `null`  |
-| dd_sqs_queue_url                  | SQS queue URL for failed event storage (takes priority over S3 when set, auto-enables `dd_store_failed_events`) | `string` | `null`  |
+| dd_sqs_queue_url                  | SQS queue URL for failed event storage (requires layer version >= 97; takes priority over S3 when set, auto-enables `dd_store_failed_events`) | `string` | `null`  |
 | dd_schedule_retry_failed_events   | Periodically retry failed events (via AWS EventBridge) | `bool`   | `null`  |
 | dd_schedule_retry_interval        | Retry interval in hours for failed events              | `number` | `6`     |
 | dd_forwarder_bucket_name          | Custom S3 bucket name                                  | `string` | `null`  |

--- a/tests/sqs_failed_events.tftest.hcl
+++ b/tests/sqs_failed_events.tftest.hcl
@@ -182,38 +182,6 @@ run "s3_fallback_unchanged" {
   }
 }
 
-# Test: SQS with old layer version fails validation
-run "sqs_with_old_layer_version_fails" {
-  command = plan
-
-  variables {
-    dd_api_key       = "test-api-key-value"
-    dd_site          = "datadoghq.com"
-    dd_sqs_queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/my-failed-events-queue"
-    layer_version    = "96"
-  }
-
-  expect_failures = [
-    var.dd_sqs_queue_url,
-  ]
-}
-
-# Test: SQS with layer version 97 succeeds
-run "sqs_with_layer_version_97" {
-  command = plan
-
-  variables {
-    dd_api_key       = "test-api-key-value"
-    dd_site          = "datadoghq.com"
-    dd_sqs_queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/my-failed-events-queue"
-    layer_version    = "97"
-  }
-
-  assert {
-    condition     = aws_lambda_function.forwarder.environment[0].variables.DD_SQS_QUEUE_URL == "https://sqs.us-east-1.amazonaws.com/123456789012/my-failed-events-queue"
-    error_message = "DD_SQS_QUEUE_URL should be set with layer version 97"
-  }
-}
 
 # Test: IAM SQS permissions are included when dd_sqs_queue_url is set
 run "iam_sqs_permissions" {

--- a/variables.tf
+++ b/variables.tf
@@ -460,11 +460,6 @@ variable "dd_sqs_queue_url" {
     condition     = var.dd_sqs_queue_url == null || can(regex("^https://sqs\\.[a-z0-9-]+\\.amazonaws\\.com[a-z.]*/[0-9]{12}/[a-zA-Z0-9_.-]+$", var.dd_sqs_queue_url))
     error_message = "dd_sqs_queue_url must be a valid SQS queue URL (e.g. https://sqs.us-east-1.amazonaws.com/123456789012/my-queue)."
   }
-
-  validation {
-    condition     = var.dd_sqs_queue_url == null || var.layer_version == "latest" || (can(tonumber(var.layer_version)) && tonumber(var.layer_version) >= 97)
-    error_message = "dd_sqs_queue_url requires forwarder layer version >= 97 (forwarder 5.3.0+). Set layer_version = \"latest\" or a version >= 97."
-  }
 }
 
 variable "dd_schedule_retry_failed_events" {


### PR DESCRIPTION
## Summary

Fixes #40 — since v1.3.1, all Terraform plans fail with `Invalid function argument` because Terraform does not short-circuit `&&`/`||` in validation conditions. The bare `tonumber(var.layer_version)` outside `can()` blows up when `layer_version` is `"latest"` (the default), breaking **all** users — not just SQS users.

## Changes

- **`variables.tf`** — Remove the cross-variable validation block on `dd_sqs_queue_url` that checked `layer_version >= 97`. The layer version requirement remains documented in the variable description.
- **`README.md`** — Add "requires layer version >= 97" to the `dd_sqs_queue_url` description in the inputs table.
- **`tests/sqs_failed_events.tftest.hcl`** — Remove `sqs_with_old_layer_version_fails` and `sqs_with_layer_version_97` test cases that asserted on the deleted validation.