### PR TITLE
fix: correct API key page link in dd_api_key description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "dd_api_key" {
   type        = string
   default     = null
   description = <<-EOT
-    The Datadog API key, which can be found from the APIs page (/account/settings#api).
+    The Datadog API key, which can be found on the API Keys page (/organization-settings/api-keys).
     When provided, the module will automatically create and manage a Secrets Manager secret.
 
     NOTE: Do not use this with dd_api_key_secret_arn or dd_api_key_ssm_parameter_name.


### PR DESCRIPTION
## What
The `dd_api_key` variable description pointed users to the deprecated `/account/settings#api` page. Updated to the current API Keys page at `/organization-settings/api-keys` (and refreshed the page name).

## Why
Part of a cleanup of stale API-key-page pointers across the Datadog Forwarder install channels. The docs team flagged the same stale path in the Forwarder CloudFormation template; this module is the Terraform install path for the same forwarder and carried an identical copy.

Related PR (Forwarder template): DataDog/datadog-serverless-functions#1164
Jira: https://datadoghq.atlassian.net/browse/AWSINTS-3805
