### PR TITLE
Replace http data source with aws_s3_object for forwarder versions

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -4,14 +4,16 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 # Fetch version mapping from public S3 bucket
-data "http" "forwarder_versions" {
-  url = "https://datadog-opensource-asset-versions.s3.us-east-1.amazonaws.com/forwarder/versions.json"
+data "aws_s3_object" "forwarder_versions" {
+  bucket = "datadog-opensource-asset-versions"
+  key    = "forwarder/versions.json"
+  region = "us-east-1"
 }
 
 # Local values
 locals {
   # Parse version mapping from S3
-  version_data = jsondecode(data.http.forwarder_versions.response_body)
+  version_data = jsondecode(data.aws_s3_object.forwarder_versions.body)
 
   # Determine layer version: use latest or specified version
   layer_version = var.layer_version == "latest" ? local.version_data.latest.layer_version : var.layer_version

--- a/examples/external-secret/external_secret.tftest.hcl
+++ b/examples/external-secret/external_secret.tftest.hcl
@@ -22,9 +22,9 @@ run "external_secret_plan_succeeds" {
   command = plan
 
   override_data {
-    target = module.datadog_forwarder.data.http.forwarder_versions
+    target = module.datadog_forwarder.data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 

--- a/tests/character_limit.tftest.hcl
+++ b/tests/character_limit.tftest.hcl
@@ -1,5 +1,11 @@
 # Test that character limits are respected
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/create_api_key_secret_flag.tftest.hcl
+++ b/tests/create_api_key_secret_flag.tftest.hcl
@@ -42,9 +42,9 @@ run "explicit_false_with_secret_arn" {
   }
 
   override_data {
-    target = data.http.forwarder_versions
+    target = data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 
@@ -71,9 +71,9 @@ run "explicit_false_with_ssm_parameter" {
   }
 
   override_data {
-    target = data.http.forwarder_versions
+    target = data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 
@@ -95,9 +95,9 @@ run "explicit_true_creates_secret" {
   }
 
   override_data {
-    target = data.http.forwarder_versions
+    target = data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 
@@ -119,9 +119,9 @@ run "null_flag_auto_creates_secret_from_api_key" {
   }
 
   override_data {
-    target = data.http.forwarder_versions
+    target = data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 
@@ -140,9 +140,9 @@ run "null_flag_auto_skips_secret_with_external_arn" {
   }
 
   override_data {
-    target = data.http.forwarder_versions
+    target = data.aws_s3_object.forwarder_versions
     values = {
-      response_body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
     }
   }
 
@@ -169,6 +169,13 @@ run "flag_false_without_arn_fails_validation" {
   expect_failures = [
     var.create_dd_api_key_secret
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # flag=true requires dd_api_key — omitting it should fail validation
@@ -184,6 +191,13 @@ run "flag_true_without_api_key_fails_validation" {
   expect_failures = [
     var.create_dd_api_key_secret
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # Invalid Secrets Manager ARN format should be rejected
@@ -197,6 +211,13 @@ run "invalid_secret_arn_format_fails_validation" {
   expect_failures = [
     var.dd_api_key_secret_arn
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # Invalid SSM parameter name (missing leading slash) should be rejected
@@ -210,6 +231,13 @@ run "invalid_ssm_parameter_name_fails_validation" {
   expect_failures = [
     var.dd_api_key_ssm_parameter_name
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -230,6 +258,13 @@ run "api_key_and_secret_arn_conflict_warns" {
   expect_failures = [
     check.dd_api_key_not_used_with_secret_arn
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # dd_api_key + dd_api_key_ssm_parameter_name should warn
@@ -244,6 +279,13 @@ run "api_key_and_ssm_parameter_conflict_warns" {
   expect_failures = [
     check.dd_api_key_not_used_with_ssm_parameter
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }
 
 # dd_api_key_secret_arn + dd_api_key_ssm_parameter_name should warn
@@ -258,4 +300,11 @@ run "secret_arn_and_ssm_parameter_conflict_warns" {
   expect_failures = [
     check.dd_secret_arn_not_used_with_ssm_parameter
   ]
+
+  override_data {
+    target = data.aws_s3_object.forwarder_versions
+    values = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{}}"
+    }
+  }
 }

--- a/tests/default_config.tftest.hcl
+++ b/tests/default_config.tftest.hcl
@@ -1,5 +1,11 @@
 # Test the default configuration of the Datadog Forwarder module
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/enhanced_features.tftest.hcl
+++ b/tests/enhanced_features.tftest.hcl
@@ -1,5 +1,11 @@
 # Test enhanced features configuration
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/enrich_fetch_variables.tftest.hcl
+++ b/tests/enrich_fetch_variables.tftest.hcl
@@ -1,4 +1,10 @@
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/existing_iam_role_without_bucket.tftest.hcl
+++ b/tests/existing_iam_role_without_bucket.tftest.hcl
@@ -3,6 +3,12 @@
 # while still letting the module create the S3 bucket
 
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/existing_resources.tftest.hcl
+++ b/tests/existing_resources.tftest.hcl
@@ -1,5 +1,11 @@
 # Test using existing IAM role and S3 bucket
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/forwarder_version_tag.tftest.hcl
+++ b/tests/forwarder_version_tag.tftest.hcl
@@ -1,5 +1,11 @@
 # Test the dd_forwarder_version tag functionality
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/multi_region.tftest.hcl
+++ b/tests/multi_region.tftest.hcl
@@ -1,5 +1,11 @@
 # Test multi-region support
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/optional_env_vars.tftest.hcl
+++ b/tests/optional_env_vars.tftest.hcl
@@ -1,5 +1,11 @@
 # Test optional environment variables are set when provided
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/s3_log_bucket_arns.tftest.hcl
+++ b/tests/s3_log_bucket_arns.tftest.hcl
@@ -1,5 +1,11 @@
 # Test S3 log bucket ARN restrictions on IAM policy
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/secrets_management.tftest.hcl
+++ b/tests/secrets_management.tftest.hcl
@@ -1,5 +1,11 @@
 # Test all API key configuration paths
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/sqs_failed_events.tftest.hcl
+++ b/tests/sqs_failed_events.tftest.hcl
@@ -1,6 +1,12 @@
 # Test SQS queue support for failed event storage
 
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"

--- a/tests/vpc_config.tftest.hcl
+++ b/tests/vpc_config.tftest.hcl
@@ -1,5 +1,11 @@
 # Test VPC configuration of the Datadog Forwarder module
 mock_provider "aws" {
+  mock_data "aws_s3_object" {
+    defaults = {
+      body = "{\"latest\":{\"layer_version\":\"92\",\"forwarder_version\":\"5.1.0\"},\"mappings\":{\"92\":\"5.1.0\"}}"
+    }
+  }
+
   mock_data "aws_caller_identity" {
     defaults = {
       account_id = "123456789012"


### PR DESCRIPTION
## Summary
- Replaces `data "http" "forwarder_versions"` with `data "aws_s3_object" "forwarder_versions"`, dropping the dependency on the separate `hashicorp/http` provider since the bucket is fetched via the already-required `aws` provider.
- Updates all `tftest.hcl` files to mock `aws_s3_object` (global defaults or per-run overrides) instead of relying on live network calls to the public S3 bucket during tests.

## Test plan
- [x] `terraform validate` passes
- [x] `terraform test` — 54/54 passing in the root module